### PR TITLE
Modify perform::mute_group_tracks to used m_screenset for active scre…

### DIFF
--- a/libseq64/src/perform.cpp
+++ b/libseq64/src/perform.cpp
@@ -401,7 +401,7 @@ perform::mute_group_tracks ()
             {
                 if (is_active(i * m_seqs_in_set + j))
                 {
-                    if ((i == m_playing_screen) && m_tracks_mute_state[j])
+                    if ((i == m_screenset) && m_tracks_mute_state[j])
                         sequence_playing_on(i * m_seqs_in_set + j);
                     else
                         sequence_playing_off(i * m_seqs_in_set + j);


### PR DESCRIPTION
This is a simple change in perform.cpp consisting of replacement of m_screen_playing with m_screenset in perform::mute_group_tracks( ).  m_screen_playing was not picking up the active screen changes so the muting was always trying to occur on screen 0.  