### PR TITLE
Mute group active screen tracking modification

### DIFF
--- a/libseq64/src/perform.cpp
+++ b/libseq64/src/perform.cpp
@@ -369,7 +369,7 @@ perform::select_mute_group (int a_group)
 {
     int group = clamp_track(a_group);
     int j = group * m_seqs_in_set;
-    int k = m_playscreen_offset;
+    int k = m_screenset * m_seqs_in_set; // replaces m_playscreen_offset
 
     /*
      * Should make this assignment contingent upon error.

--- a/libseq64/src/perform.cpp
+++ b/libseq64/src/perform.cpp
@@ -401,7 +401,7 @@ perform::mute_group_tracks ()
             {
                 if (is_active(i * m_seqs_in_set + j))
                 {
-                    if ((i == m_playing_screen) && m_tracks_mute_state[j])
+                    if ((i == m_screenset) && m_tracks_mute_state[j])
                         sequence_playing_on(i * m_seqs_in_set + j);
                     else
                         sequence_playing_off(i * m_seqs_in_set + j);


### PR DESCRIPTION
This is a replacement for the incomplete pull request https://github.com/ahlstromcj/sequencer64/pull/3 as a response to issue https://github.com/ahlstromcj/sequencer64/issues/5 

This pull request modifies ***perform::select_mute_group()*** and ***perform::mute_group_tracks()*** to change expressions that should have been tracking the active screen; **m_playing_screen** and **m_playscreen_offset**, but weren't working, with expressions that do.  The replacement expressions; **m_screenset** for the active screen number and **m_screenset * m_seqs_in_set** for the active screen offset.  These expressions may not be the best choices for the larger context of the source, but they're fairly basic and work well.

These changes allow the chosen mute group to be applied as an overlay to the tracks on the active screen, turning off all tracks on all other screens.  The prior behavior was to only pick up and apply mute groups to screen 0.