### PR TITLE
Add support for DESTDIR to make target doc/dox.

### DIFF
--- a/doc/dox/Makefile.am
+++ b/doc/dox/Makefile.am
@@ -57,8 +57,8 @@ clean-local:
 #------------------------------------------------------------------------------
 
 install-data-local:
-	mkdir -p /usr/local/doc/sequencer64
-	cp -r -p $(top_builddir)/doc/*.pdf /usr/local/doc/sequencer64
+	mkdir -p $(DESTDIR)$(sequencer64docdir)
+	cp -r -p $(top_builddir)/doc/*.pdf $(DESTDIR)$(sequencer64docdir)
 
 #*******************************************************************************
 # uninstall-hook
@@ -69,7 +69,7 @@ install-data-local:
 #-------------------------------------------------------------------------------
 
 uninstall-hook:
-	rm -rf /usr/local/doc/sequencer64
+	rm -rf $(DESTDIR)$(sequencer64docdir)
 
 #******************************************************************************
 # Makefile.am (dox)


### PR DESCRIPTION
I have tried to create a sequencer64 user package for Arch Linux. In order to create an AUR package, everything is "installed" with user privileges into your home directory first. This heavily depends on make's DESTDIR variable.
Hard coded paths in make target doc/dox made this process impossible before.