### PR TITLE
Temporary fix for copy/paste bug (order of events) added.

### DIFF
--- a/libseq64/src/sequence.cpp
+++ b/libseq64/src/sequence.cpp
@@ -1399,6 +1399,24 @@ sequence::paste_selected (midipulse tick, int note)
             DREF(i).set_note(DREF(i).get_note() - (highest_note - note));
         }
     }
+	
+#ifdef SEQ64_USE_EVENT_MAP
+    /* 
+     * TEMPORARY FIX:
+     * The event_keys used to access/sort the multimap event_list is not
+     * updated after changing timestamp/rank of the stored events.
+     * Regenerating all key/value pairs before merging them solves this 
+     * issue temporarily, so that the order of events in the sequence will
+     * be preserved:
+     */
+    event_list clipbd_updated;
+    for (event_list::iterator i = clipbd.begin(); i != clipbd.end(); ++i)
+    {
+        clipbd_updated.add( DREF(i) );
+    }
+    clipbd = clipbd_updated;
+#endif // SEQ64_USE_EVENT_MAP
+	
     m_events.merge(clipbd, false);              /* don't presort clipboard  */
     m_events.sort();
     verify_and_link();


### PR DESCRIPTION
Copy/pasting events did leave the sequence in an unordered state (key/value pairs in the multimap based event_list out of sync). Regenerating the clipboard event_list with all the keys before merging them helps, but is certainly not a perfect fix! (Working on master, since I don't know how the branches are organized.)