### PR TITLE
Make measure and beat_per_measure entries editable

### DIFF
--- a/seq_gtkmm2/include/seqedit.hpp
+++ b/seq_gtkmm2/include/seqedit.hpp
@@ -400,6 +400,7 @@ private:
     void set_snap (int snap);
     void set_note_length (int note_length);
     void set_beats_per_bar (int bpm);
+    void set_beats_per_bar_manual ();
     void set_beat_width (int bw);
     void set_transpose_image (bool istransposable);
     void set_rec_vol (int recvol);
@@ -461,6 +462,7 @@ private:
     }
 
     void set_measures (int lim);
+    void set_measures_manual ();
     void apply_length (midibpm bpm, int bw, int measures);
     long get_measures ();
     void set_midi_channel (int midichannel, bool user_change = false);

--- a/seq_gtkmm2/src/seqedit.cpp
+++ b/seq_gtkmm2/src/seqedit.cpp
@@ -1175,7 +1175,11 @@ seqedit::fill_top_bar ()
     );
     m_entry_bpm = manage(new Gtk::Entry());
     m_entry_bpm->set_width_chars(2);
-    m_entry_bpm->set_editable(false);
+    m_entry_bpm->set_editable(true);
+    m_entry_bpm->signal_activate().connect
+    (
+        mem_fun(*this, &seqedit::set_beats_per_bar_manual)
+    );
     m_hbox->pack_start(*m_button_bpm , false, false);
     m_hbox->pack_start(*m_entry_bpm , false, false);
     m_hbox->pack_start(*(manage(new Gtk::Label("/"))), false, false, 4);
@@ -1200,7 +1204,11 @@ seqedit::fill_top_bar ()
     add_tooltip(m_button_length, "Sequence length in measures or bars.");
     m_entry_length = manage(new Gtk::Entry());
     m_entry_length->set_width_chars(3);
-    m_entry_length->set_editable(false);
+    m_entry_length->set_editable(true);
+    m_entry_length->signal_activate().connect
+    (
+        mem_fun(*this, &seqedit::set_measures_manual)
+    );
     m_hbox->pack_start(*m_button_length , false, false);
     m_hbox->pack_start(*m_entry_length , false, false);
     m_hbox->pack_start(*m_toggle_transpose, false, false, 4);
@@ -2064,6 +2072,20 @@ seqedit::set_measures (int lim)
 }
 
 /**
+ *  Set the measures value manually
+ */
+
+void
+seqedit::set_measures_manual ()
+{
+    int lim = atoi( m_entry_length->get_text().c_str() );
+
+    if (lim > 0 && lim < 1025)
+        this->set_measures(lim);
+}
+
+
+/**
  *  Set the bpm (beats per measure) value, using the given parameter, and
  *  some internal values passed to apply_length().
  *
@@ -2087,6 +2109,20 @@ seqedit::set_beats_per_bar (int bpm)
         apply_length(bpm, m_seq.get_beat_width(), len);
     }
 }
+
+/**
+ *  Set the bpm (beats per measure) value manually
+ */
+
+void
+seqedit::set_beats_per_bar_manual ()
+{
+    int bpm = atoi( m_entry_bpm->get_text().c_str() );
+
+    if (bpm > 0 && bpm < 129)
+        this->set_beats_per_bar(bpm);
+ }
+
 
 /**
  *  Set the bw (beat width) value, using the given parameter, and


### PR DESCRIPTION
This PR allows the user to set the beat-per-measures and measures parameters manually by making them editable, it can be really usefull sometimes !