### PR TITLE
Pattern panel scrollbars

### DIFF
--- a/seq_gtkmm2/include/mainwnd.hpp
+++ b/seq_gtkmm2/include/mainwnd.hpp
@@ -64,11 +64,13 @@ namespace Gtk
     class Button;
     class Cursor;
     class Entry;
+    class HScrollbar;
     class Label;
     class MenuBar;
     class Menu;
     class SpinButton;
     class Tooltips;
+    class VScrollbar;
 
 #if defined SEQ64_STAZED_MENU_BUTTONS
     class ToggleButton;
@@ -128,6 +130,15 @@ private:
      */
 
     int m_ppqn;
+
+    /**
+     *  Patterns Panel scrollable wrapper
+     */
+
+     Gtk::Adjustment * m_hadjust;
+     Gtk::Adjustment * m_vadjust;
+     Gtk::HScrollbar * m_hscroll;
+     Gtk::VScrollbar * m_vscroll;
 
     /**
      *  The biggest sub-components of mainwnd.  The first is the Patterns
@@ -497,6 +508,9 @@ private:
     bool on_delete_event (GdkEventAny * ev);
     bool on_key_press_event (GdkEventKey * ev);
     bool on_key_release_event (GdkEventKey * ev);
+    bool on_scroll_event (GdkEventScroll * ev);
+    void on_hscroll_resize ();
+    void on_vscroll_resize ();
     void on_realize ();
 
 private:

--- a/seq_gtkmm2/src/mainwnd.cpp
+++ b/seq_gtkmm2/src/mainwnd.cpp
@@ -686,6 +686,9 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
     /*
      * Prevent window size jumps when resizing near scrollbars' appearance point
      * Add scrollbars only after to make sure their size are not added
+     *
+     * If set_size_request() is not called, the window will request its natural
+     * size (determined by its content) when scrollbars appear or disappear
      */
 
     set_size_request(

--- a/seq_gtkmm2/src/mainwnd.cpp
+++ b/seq_gtkmm2/src/mainwnd.cpp
@@ -2302,25 +2302,24 @@ mainwnd::on_key_press_event (GdkEventKey * ev)
 bool
 mainwnd::on_scroll_event (GdkEventScroll * ev)
 {
-    if (ev->direction == GDK_SCROLL_UP ||
-        ev->direction == GDK_SCROLL_DOWN) {
+    if (ev->direction == GDK_SCROLL_LEFT  ||
+        ev->direction == GDK_SCROLL_RIGHT || is_shift_key(ev))
+    {
+        double v = ev->direction == GDK_SCROLL_LEFT ||
+                   ev->direction == GDK_SCROLL_UP ?
+            m_hadjust->get_value() - m_hadjust->get_step_increment():
+            m_hadjust->get_value() + m_hadjust->get_step_increment();
 
+        m_hadjust->clamp_page(v, v + m_hadjust->get_page_size());
+    }
+    else if (ev->direction == GDK_SCROLL_UP ||
+             ev->direction == GDK_SCROLL_DOWN)
+    {
         double v = ev->direction == GDK_SCROLL_UP ?
                 m_vadjust->get_value() - m_vadjust->get_step_increment():
                 m_vadjust->get_value() + m_vadjust->get_step_increment();
 
         m_vadjust->clamp_page(v, v + m_vadjust->get_page_size());
-
-
-    } else if (ev->direction == GDK_SCROLL_LEFT ||
-               ev->direction == GDK_SCROLL_RIGHT) {
-
-        double v = ev->direction == GDK_SCROLL_LEFT ?
-                m_hadjust->get_value() - m_hadjust->get_step_increment():
-                m_hadjust->get_value() + m_hadjust->get_step_increment();
-
-        m_hadjust->clamp_page(v, v + m_hadjust->get_page_size());
-
     }
 
     return true;

--- a/seq_gtkmm2/src/mainwnd.cpp
+++ b/seq_gtkmm2/src/mainwnd.cpp
@@ -623,17 +623,25 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
      * Pattern panel scrollable wrapper
      */
 
-    Gtk::Viewport * m_main_wid_viewport = new Gtk::Viewport(*m_hadjust, *m_vadjust);
-    m_main_wid_viewport->set_shadow_type(Gtk::SHADOW_NONE);
-    m_main_wid_viewport->add(*m_main_wid);
+    Gtk::Viewport * viewport = new Gtk::Viewport(*m_hadjust, *m_vadjust);
+    viewport->set_shadow_type(Gtk::SHADOW_NONE);
+    viewport->add(*m_main_wid);
+
+    Gtk::HBox * mainwid_vscroll_wrapper = new Gtk::HBox();
+    mainwid_vscroll_wrapper->set_spacing(10);
+    mainwid_vscroll_wrapper->pack_start(*viewport, Gtk::PACK_EXPAND_WIDGET);
+
+    Gtk::VBox * mainwid_hscroll_wrapper = new Gtk::VBox();
+    mainwid_hscroll_wrapper->set_spacing(10);
+    mainwid_hscroll_wrapper->pack_start
+    (
+        *mainwid_vscroll_wrapper, Gtk::PACK_EXPAND_WIDGET
+    );
+
     m_main_wid->signal_scroll_event().connect
     (
         mem_fun(*this, &mainwnd::on_scroll_event)
     );
-    Gtk::HBox * m_main_wid_hbox = new Gtk::HBox();
-    m_main_wid_hbox->set_spacing(10);
-    m_main_wid_hbox->pack_start(*m_main_wid_viewport, Gtk::PACK_EXPAND_WIDGET);
-    m_main_wid_hbox->pack_start(*m_vscroll, false, false);
     m_hadjust->signal_changed().connect
     (
         mem_fun(*this, &mainwnd::on_hscroll_resize)
@@ -654,8 +662,7 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
     contentvbox->set_spacing(10);
     contentvbox->set_border_width(10);
     contentvbox->pack_start(*tophbox, Gtk::PACK_SHRINK);
-    contentvbox->pack_start(*m_main_wid_hbox, true, true);
-    contentvbox->pack_start(*m_hscroll, false, false);
+    contentvbox->pack_start(*mainwid_hscroll_wrapper, true, true);
     contentvbox->pack_start(*bottomhbox, false, false);
     m_main_wid->set_can_focus();            /* from stazed */
     m_main_wid->grab_focus();
@@ -677,11 +684,16 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
 
     /*
      * Prevent window size jumps when resizing near scrollbars' appearance point
+     * Add scrollbars only after to make sure their size are not added
      */
+
     set_size_request(
         mainvbox->get_allocation().get_width(),
         mainvbox->get_allocation().get_height()
     );
+    mainwid_hscroll_wrapper->pack_start(*m_hscroll, false, false);
+    mainwid_vscroll_wrapper->pack_start(*m_vscroll, false, false);
+
 
     install_signal_handlers();
 }

--- a/seq_gtkmm2/src/mainwnd.cpp
+++ b/seq_gtkmm2/src/mainwnd.cpp
@@ -626,11 +626,19 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
     Gtk::Layout * mainwid_wrapper = new Gtk::Layout(*m_hadjust, *m_vadjust);
     mainwid_wrapper->add(*m_main_wid);
     mainwid_wrapper->set_size(m_main_wid->m_mainwid_x,m_main_wid->m_mainwid_y);
-    mainwid_wrapper->set_size_request(m_main_wid->m_mainwid_x,m_main_wid->m_mainwid_y);
+    mainwid_wrapper->set_size_request
+    (
+        m_main_wid->m_mainwid_x,
+        m_main_wid->m_mainwid_y
+    );
 
     Gtk::HBox * mainwid_vscroll_wrapper = new Gtk::HBox();
     mainwid_vscroll_wrapper->set_spacing(10);
-    mainwid_vscroll_wrapper->pack_start(*mainwid_wrapper, Gtk::PACK_EXPAND_WIDGET);
+    mainwid_vscroll_wrapper->pack_start
+    (
+        *mainwid_wrapper,
+        Gtk::PACK_EXPAND_WIDGET
+    );
 
     Gtk::VBox * mainwid_hscroll_wrapper = new Gtk::VBox();
     mainwid_hscroll_wrapper->set_spacing(10);
@@ -645,11 +653,11 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
     );
     m_hadjust->signal_changed().connect
     (
-        mem_fun(*this, &mainwnd::on_hscroll_resize)
+        mem_fun(*this, &mainwnd::on_scrollbar_resize)
     );
     m_vadjust->signal_changed().connect
     (
-        mem_fun(*this, &mainwnd::on_vscroll_resize)
+        mem_fun(*this, &mainwnd::on_scrollbar_resize)
     );
 
     /*
@@ -2319,19 +2327,18 @@ mainwnd::on_scroll_event (GdkEventScroll * ev)
 }
 
 void
-mainwnd::on_hscroll_resize ()
+mainwnd::on_scrollbar_resize ()
 {
-    bool visible = m_hadjust->get_page_size() != m_hadjust->get_upper();
-    if (m_hscroll->get_visible() != visible)
-        m_hscroll->set_visible(visible);
-}
+    int bar = m_vscroll->get_allocation().get_width() + 10;
 
-void
-mainwnd::on_vscroll_resize ()
-{
-    bool visible = m_vadjust->get_page_size() != m_vadjust->get_upper();
-    if (m_vscroll->get_visible() != visible)
-        m_vscroll->set_visible(visible);
+    bool h_visible = (m_vscroll->get_visible() ? bar : 0) < m_hadjust->get_upper() - m_hadjust->get_page_size();
+    bool v_visible = (m_hscroll->get_visible() ? bar : 0) < m_vadjust->get_upper() - m_vadjust->get_page_size();
+
+    if (m_hscroll->get_visible() != h_visible)
+        m_hscroll->set_visible(h_visible);
+
+    if (m_vscroll->get_visible() != v_visible)
+        m_vscroll->set_visible(v_visible);
 }
 
 /**

--- a/seq_gtkmm2/src/mainwnd.cpp
+++ b/seq_gtkmm2/src/mainwnd.cpp
@@ -633,7 +633,7 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
     );
 
     Gtk::HBox * mainwid_vscroll_wrapper = new Gtk::HBox();
-    mainwid_vscroll_wrapper->set_spacing(10);
+    mainwid_vscroll_wrapper->set_spacing(5);
     mainwid_vscroll_wrapper->pack_start
     (
         *mainwid_wrapper,
@@ -641,7 +641,7 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
     );
 
     Gtk::VBox * mainwid_hscroll_wrapper = new Gtk::VBox();
-    mainwid_hscroll_wrapper->set_spacing(10);
+    mainwid_hscroll_wrapper->set_spacing(5);
     mainwid_hscroll_wrapper->pack_start
     (
         *mainwid_vscroll_wrapper, Gtk::PACK_EXPAND_WIDGET
@@ -2329,7 +2329,7 @@ mainwnd::on_scroll_event (GdkEventScroll * ev)
 void
 mainwnd::on_scrollbar_resize ()
 {
-    int bar = m_vscroll->get_allocation().get_width() + 10;
+    int bar = m_vscroll->get_allocation().get_width() + 5;
 
     bool h_visible = (m_vscroll->get_visible() ? bar : 0) < m_hadjust->get_upper() - m_hadjust->get_page_size();
     bool v_visible = (m_hscroll->get_visible() ? bar : 0) < m_vadjust->get_upper() - m_vadjust->get_page_size();

--- a/seq_gtkmm2/src/mainwnd.cpp
+++ b/seq_gtkmm2/src/mainwnd.cpp
@@ -620,13 +620,8 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
     bottomhbox->pack_end(*m_button_perfedit, Gtk::PACK_SHRINK);
 
     /*
-     * Vertical layout container for window content.  Letting Gtk manage it
-     * does not improve leaks:
-     *
-     * Gtk::VBox * contentvbox = manage(new Gtk::VBox());
+     * Pattern panel scrollable wrapper
      */
-
-    Gtk::VBox * contentvbox = new Gtk::VBox();
 
     Gtk::Viewport * m_main_wid_viewport = new Gtk::Viewport(*m_hadjust, *m_vadjust);
     m_main_wid_viewport->set_shadow_type(Gtk::SHADOW_NONE);
@@ -648,6 +643,14 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
         mem_fun(*this, &mainwnd::on_vscroll_resize)
     );
 
+    /*
+     * Vertical layout container for window content.  Letting Gtk manage it
+     * does not improve leaks:
+     *
+     * Gtk::VBox * contentvbox = manage(new Gtk::VBox());
+     */
+
+    Gtk::VBox * contentvbox = new Gtk::VBox();
     contentvbox->set_spacing(10);
     contentvbox->set_border_width(10);
     contentvbox->pack_start(*tophbox, Gtk::PACK_SHRINK);
@@ -671,6 +674,15 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
         mem_fun(*this, &mainwnd::timer_callback), redraw_period_ms()
     );
     show_all();                             /* works here as well           */
+
+    /*
+     * Prevent window size jumps when resizing near scrollbars' appearance point
+     */
+    set_size_request(
+        mainvbox->get_allocation().get_width(),
+        mainvbox->get_allocation().get_height()
+    );
+
     install_signal_handlers();
 }
 

--- a/seq_gtkmm2/src/mainwnd.cpp
+++ b/seq_gtkmm2/src/mainwnd.cpp
@@ -83,7 +83,7 @@
 #include <gtkmm/spinbutton.h>
 #include <gtkmm/stock.h>
 #include <gtkmm/tooltips.h>
-#include <gtkmm/viewport.h>
+#include <gtkmm/layout.h>
 #include <gtkmm/scrollbar.h>
 
 #include "globals.h"
@@ -192,8 +192,8 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
     m_menu_view             (manage(new Gtk::Menu())),
     m_menu_help             (manage(new Gtk::Menu())),
     m_ppqn                  (choose_ppqn(ppqn)),
-    m_hadjust               (manage(new Gtk::Adjustment(0,0,1,1,1,1))),
-    m_vadjust               (manage(new Gtk::Adjustment(0,0,1,1,1,1))),
+    m_hadjust               (manage(new Gtk::Adjustment(0,0,1,10,100,0))),
+    m_vadjust               (manage(new Gtk::Adjustment(0,0,1,10,100,0))),
     m_hscroll               (manage(new Gtk::HScrollbar(*m_hadjust))),
     m_vscroll               (manage(new Gtk::VScrollbar(*m_vadjust))),
     m_main_wid              (manage(new mainwid(p))),
@@ -623,13 +623,14 @@ mainwnd::mainwnd (perform & p, bool allowperf2, int ppqn)
      * Pattern panel scrollable wrapper
      */
 
-    Gtk::Viewport * viewport = new Gtk::Viewport(*m_hadjust, *m_vadjust);
-    viewport->set_shadow_type(Gtk::SHADOW_NONE);
-    viewport->add(*m_main_wid);
+    Gtk::Layout * mainwid_wrapper = new Gtk::Layout(*m_hadjust, *m_vadjust);
+    mainwid_wrapper->add(*m_main_wid);
+    mainwid_wrapper->set_size(m_main_wid->m_mainwid_x,m_main_wid->m_mainwid_y);
+    mainwid_wrapper->set_size_request(m_main_wid->m_mainwid_x,m_main_wid->m_mainwid_y);
 
     Gtk::HBox * mainwid_vscroll_wrapper = new Gtk::HBox();
     mainwid_vscroll_wrapper->set_spacing(10);
-    mainwid_vscroll_wrapper->pack_start(*viewport, Gtk::PACK_EXPAND_WIDGET);
+    mainwid_vscroll_wrapper->pack_start(*mainwid_wrapper, Gtk::PACK_EXPAND_WIDGET);
 
     Gtk::VBox * mainwid_hscroll_wrapper = new Gtk::VBox();
     mainwid_hscroll_wrapper->set_spacing(10);
@@ -1753,6 +1754,7 @@ mainwnd::adj_callback_bpm ()
     perf().set_beats_per_minute(midibpm(m_adjust_bpm->get_value()));
 }
 
+
 /**
  *  A callback function for handling an edit to the screen-set notepad.
  *  Let the perform object keep track of modifications.
@@ -2317,9 +2319,8 @@ void
 mainwnd::on_hscroll_resize ()
 {
     bool visible = m_hadjust->get_page_size() != m_hadjust->get_upper();
-    if (m_hscroll->get_visible() != visible) {
+    if (m_hscroll->get_visible() != visible)
         m_hscroll->set_visible(visible);
-    }
 }
 
 void


### PR DESCRIPTION
- the mainwid object is wrapped in a Layout and 2 Boxes (one for each scrollbar, I tried with a Table but I didn't behave well with fill/expand/shrink options 
- the bottom bar is now fixed to the bottom of the window, it looks better when resized
- scrollbar autohide :-)
- the mainwnd object explicilty requires a size based on its contents' at init, otherwise it would jump to its natural size when the scrollbars appear / disappear