### PR TITLE
Fix for note off not being played when cutting or moving notes.

### DIFF
--- a/libseq64/src/sequence.cpp
+++ b/libseq64/src/sequence.cpp
@@ -1186,6 +1186,21 @@ bool
 sequence::remove_marked ()
 {
     automutex locker(m_mutex);
+    //We have to make note off before moving and cutting. Here or in event_list?
+    for (event_list::iterator i = m_events.begin(); i != m_events.end(); ++i)
+    {
+     const event & e = m_events.dref(i);
+
+        if(e.is_marked())
+        {
+                 if(e.is_note_on()) //Or maybe just e.is_note()?
+                 {
+                   midibyte note_to_play = e.get_note();
+                   this->play_note_off((int)note_to_play);
+                 }
+
+        }
+    }
     bool result = m_events.remove_marked();
     reset_draw_marker();
     return result;


### PR DESCRIPTION
When cut or move is made before note off is played the event list is updated and thus note off is not played  and the note is always on. I made a fix in sequencer.cpp to play note off if event is marked and atm if event is note_on.

To test this make a long note and  make cut in the middle before note of. The note stays on. 

