### PR TITLE
Fix configure.ac: use rtmidi as default backend

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -522,7 +522,7 @@ dnl Eventually we want to make ALSA optional for the user/developer.
 AC_ARG_ENABLE(rtmidi,
     [AS_HELP_STRING(--enable-rtmidi, [Enable rtmidi build])],
     [rtmidi=$enableval],
-    [rtmidi=no])
+    [rtmidi=yes])
 
 if test "$rtmidi" != "no"; then
     build_rtmidi="yes"


### PR DESCRIPTION
Fixes #116 

This makes a simple
```
./bootstrap
./configure
make
```

work again for me.

Thought I might as well create a PR to fix it :)