### PR TITLE
m4/configure: Add missing QtWidgets check

### DIFF
--- a/m4/ax_have_qt.m4
+++ b/m4/ax_have_qt.m4
@@ -102,6 +102,7 @@ qtHaveModule(testlib):           QT += testlib
 qtHaveModule(uitools):           QT += uitools
 qtHaveModule(webkit):            QT += webkit
 qtHaveModule(webkitwidgets):     QT += webkitwidgets
+qtHaveModule(widgets):           QT += widgets
 qtHaveModule(xml):               QT += xml
 qtHaveModule(xmlpatterns):       QT += xmlpatterns
 percent.target = %


### PR DESCRIPTION
Small fix to make compilation of the Qt5 GUI work when QtDesigner isn't installed. Somehow the check for designer also includes the check for QtWidgets (and other Qt packages) so you probably never noticed :)